### PR TITLE
Thrust core benchmarks

### DIFF
--- a/benches/thrust/adjacent_difference/basic.cu
+++ b/benches/thrust/adjacent_difference/basic.cu
@@ -1,0 +1,35 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/adjacent_difference.h>
+#include <thrust/device_vector.h>
+
+template <typename T>
+static void basic(nvbench::state &state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements, T(42));
+  thrust::device_vector<T> output(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements, "Size");
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync,
+             [&](nvbench::launch &launch) {
+               const auto policy = thrust::device.on(launch.get_stream());
+               thrust::adjacent_difference(policy,
+                                           input.begin(),
+                                           input.end(),
+                                           output.begin());
+             });
+}
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t,
+                                 nvbench::float32_t,
+                                 nvbench::float64_t>;
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::adjacent_difference (basic)")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2));

--- a/benches/thrust/adjacent_difference/basic.cu
+++ b/benches/thrust/adjacent_difference/basic.cu
@@ -2,6 +2,7 @@
 
 #include <thrust/adjacent_difference.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 
 template <typename T>
 static void basic(nvbench::state &state, nvbench::type_list<T>)

--- a/benches/thrust/adjacent_difference/custom.cu
+++ b/benches/thrust/adjacent_difference/custom.cu
@@ -1,0 +1,52 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/adjacent_difference.h>
+#include <thrust/device_vector.h>
+
+template <typename T>
+struct custom_op
+{
+  T val;
+
+  custom_op() = delete;
+
+  explicit custom_op(T val)
+      : val(val)
+  {}
+
+  __device__ T operator()(const T &lhs, const T &rhs)
+  {
+    return lhs * rhs + val; // Hope to gen mad
+  }
+};
+
+template <typename T>
+static void custom(nvbench::state &state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements, T(42));
+  thrust::device_vector<T> output(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements, "Size");
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    const auto policy = thrust::device.on(launch.get_stream());
+    thrust::adjacent_difference(policy,
+                                input.begin(),
+                                input.end(),
+                                output.begin(),
+                                custom_op<T>(42));
+  });
+}
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t,
+                                 nvbench::float32_t,
+                                 nvbench::float64_t>;
+NVBENCH_BENCH_TYPES(custom, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::adjacent_difference (custom)")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2));

--- a/benches/thrust/adjacent_difference/custom.cu
+++ b/benches/thrust/adjacent_difference/custom.cu
@@ -2,6 +2,7 @@
 
 #include <thrust/adjacent_difference.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 
 template <typename T>
 struct custom_op

--- a/benches/thrust/adjacent_difference/in_place.cu
+++ b/benches/thrust/adjacent_difference/in_place.cu
@@ -1,0 +1,33 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/adjacent_difference.h>
+#include <thrust/device_vector.h>
+
+template <typename T>
+static void in_place(nvbench::state &state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements, T(42));
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements, "Size");
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    const auto policy = thrust::device.on(launch.get_stream());
+    thrust::adjacent_difference(policy,
+                                input.begin(),
+                                input.end(),
+                                input.begin());
+  });
+}
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t,
+                                 nvbench::float32_t,
+                                 nvbench::float64_t>;
+NVBENCH_BENCH_TYPES(in_place, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::adjacent_difference (in_place)")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2));

--- a/benches/thrust/adjacent_difference/in_place.cu
+++ b/benches/thrust/adjacent_difference/in_place.cu
@@ -2,6 +2,7 @@
 
 #include <thrust/adjacent_difference.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 
 template <typename T>
 static void in_place(nvbench::state &state, nvbench::type_list<T>)

--- a/benches/thrust/copy/basic.cu
+++ b/benches/thrust/copy/basic.cu
@@ -1,0 +1,36 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/copy.h>
+
+template <typename T>
+static void basic(nvbench::state &state,
+                  nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements);
+  thrust::device_vector<T> output(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+
+    thrust::copy(policy,
+                 input.cbegin(),
+                 input.cend(),
+                 output.begin());
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::copy")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2));

--- a/benches/thrust/copy/basic.cu
+++ b/benches/thrust/copy/basic.cu
@@ -1,6 +1,8 @@
 #include <nvbench/nvbench.cuh>
 
+#include <thrust/count.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 #include <thrust/copy.h>
 
 template <typename T>

--- a/benches/thrust/copy/if.cu
+++ b/benches/thrust/copy/if.cu
@@ -1,0 +1,165 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/copy.h>
+
+#include <tbm/range_generator.cuh>
+
+enum class select_op_type
+{
+  greater_than_middle,
+  greater_than_zero,
+  even
+  // complex predicate case is covered
+  // in the thrust/partition/complex_predicate.cu
+};
+
+template <typename T>
+struct gt_select_op
+{
+  T m_val {};
+
+  explicit gt_select_op(T val)
+      : m_val(val)
+  {}
+
+  __device__ bool operator()(const T& val)
+  {
+    return val > m_val;
+  }
+};
+
+template <typename T>
+struct even_select_op
+{
+  __device__ bool operator()(const T& val)
+  {
+    return (val % 2) == 0;
+  }
+};
+
+template <select_op_type op_type>
+struct op_construction_helper;
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_middle>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(T elements)
+  {
+    return gt_select_op<T>{static_cast<T>(elements / 2)};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_zero>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(int /* elements */)
+  {
+    return gt_select_op<T>{T{}};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::even>
+{
+  template <typename T>
+  static even_select_op<T> create_select_op(int /* elements */)
+  {
+    return even_select_op<T>{};
+  }
+};
+
+template <typename T, select_op_type SelectOpType, tbm::data_pattern Pattern>
+static void basic(nvbench::state &state,
+                  nvbench::type_list<T,
+                                     nvbench::enum_type<SelectOpType>,
+                                     nvbench::enum_type<Pattern>>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  auto input =
+    tbm::make_range_generator<T, tbm::iterator_style::pointer, Pattern>(
+      elements);
+
+  thrust::device_vector<T> output(elements);
+
+  auto select_op =
+    op_construction_helper<SelectOpType>::template create_select_op<T>(
+      elements);
+
+  auto selected_elements =
+    thrust::count_if(thrust::device, input.cbegin(), input.cend(), select_op);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads(input.get_allocation_size());
+  state.add_global_memory_writes<T>(selected_elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+
+    thrust::copy_if(policy,
+                    input.cbegin(),
+                    input.cend(),
+                    output.begin(),
+                    select_op);
+  });
+}
+
+// Column names for type axes:
+inline std::vector<std::string> select_if_type_axis_names()
+{
+  return {"T", "Op", "Pattern"};
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;
+
+using ops = nvbench::enum_type_list<select_op_type::greater_than_middle,
+                                    select_op_type::greater_than_zero,
+                                    select_op_type::even>;
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  select_op_type,
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Mid";
+      case select_op_type::greater_than_zero:
+        return "Zero";
+      case select_op_type::even:
+        return "Even";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  },
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Return true for elements > Elements/2";
+      case select_op_type::greater_than_zero:
+        return "Return true for all elements";
+      case select_op_type::even:
+        return "Return true for even elements";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  })
+
+using all_input_data_patterns =
+  nvbench::enum_type_list<tbm::data_pattern::sequence,
+                          tbm::data_pattern::constant,
+                          tbm::data_pattern::random>;
+
+NVBENCH_BENCH_TYPES(basic,
+                    NVBENCH_TYPE_AXES(types, ops, all_input_data_patterns))
+  .set_name("thrust::copy_if")
+  .set_type_axes_names(select_if_type_axis_names())
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2));

--- a/benches/thrust/copy/if.cu
+++ b/benches/thrust/copy/if.cu
@@ -1,7 +1,9 @@
 #include <nvbench/nvbench.cuh>
 
-#include <thrust/device_vector.h>
+#include <thrust/count.h>
 #include <thrust/copy.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 
 #include <tbm/range_generator.cuh>
 
@@ -13,6 +15,37 @@ enum class select_op_type
   // complex predicate case is covered
   // in the thrust/partition/complex_predicate.cu
 };
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  select_op_type,
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Mid";
+      case select_op_type::greater_than_zero:
+        return "Zero";
+      case select_op_type::even:
+        return "Even";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  },
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Return true for elements > Elements/2";
+      case select_op_type::greater_than_zero:
+        return "Return true for all elements";
+      case select_op_type::even:
+        return "Return true for even elements";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  })
 
 template <typename T>
 struct gt_select_op
@@ -121,37 +154,6 @@ using types = nvbench::type_list<nvbench::uint8_t,
 using ops = nvbench::enum_type_list<select_op_type::greater_than_middle,
                                     select_op_type::greater_than_zero,
                                     select_op_type::even>;
-
-NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
-  select_op_type,
-  [](select_op_type select_op) {
-    switch (select_op)
-    {
-      case select_op_type::greater_than_middle:
-        return "Mid";
-      case select_op_type::greater_than_zero:
-        return "Zero";
-      case select_op_type::even:
-        return "Even";
-      default:
-        break;
-    }
-    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
-  },
-  [](select_op_type select_op) {
-    switch (select_op)
-    {
-      case select_op_type::greater_than_middle:
-        return "Return true for elements > Elements/2";
-      case select_op_type::greater_than_zero:
-        return "Return true for all elements";
-      case select_op_type::even:
-        return "Return true for even elements";
-      default:
-        break;
-    }
-    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
-  })
 
 using all_input_data_patterns =
   nvbench::enum_type_list<tbm::data_pattern::sequence,

--- a/benches/thrust/exclusive_scan/by_key.cu
+++ b/benches/thrust/exclusive_scan/by_key.cu
@@ -1,0 +1,64 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/scan.h>
+#include <thrust/sequence.h>
+
+#include <tbm/range_generator.cuh>
+
+template <typename T>
+thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
+{
+  std::size_t elements = keys.size();
+
+  auto random_input =
+    tbm::make_range_generator<T,
+                              tbm::iterator_style::pointer,
+                              tbm::data_pattern::random>(elements);
+
+  thrust::copy(random_input.cbegin(), random_input.cend(), keys.begin());
+  thrust::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+template <typename T>
+void by_key(nvbench::state &state, nvbench::type_list<T>)
+{
+  const auto elements = state.get_int64("Elements");
+  thrust::device_vector<T> keys(elements);
+  thrust::device_vector<T> in_values(elements);
+  thrust::device_vector<T> out_values(elements);
+
+  const auto pattern = state.get_string("Pattern");
+  if (pattern == "single")
+  {
+    // keys is filled with 0
+  }
+  else if (pattern == "random")
+  {
+    gen_keys(keys);
+  }
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+    thrust::exclusive_scan_by_key(policy,
+                                  keys.cbegin(),
+                                  keys.cend(),
+                                  in_values.begin(),
+                                  out_values.begin());
+  });
+}
+using types = nvbench::type_list<nvbench::int8_t,
+                                 nvbench::int16_t,
+                                 nvbench::int32_t,
+                                 nvbench::int64_t,
+                                 nvbench::float32_t,
+                                 nvbench::float64_t>;
+NVBENCH_BENCH_TYPES(by_key, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::exclusive_scan_by_key")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 30, 2))
+  .add_string_axis("Pattern", {"single", "random"});

--- a/benches/thrust/exclusive_scan/by_key.cu
+++ b/benches/thrust/exclusive_scan/by_key.cu
@@ -1,12 +1,13 @@
 #include <nvbench/nvbench.cuh>
 
 #include <thrust/device_vector.h>
+#include <thrust/sort.h>
 #include <thrust/scan.h>
 
 #include <tbm/range_generator.cuh>
 
 template <typename T>
-thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
+void gen_keys(thrust::device_vector<T> &keys)
 {
   std::size_t elements = keys.size();
 
@@ -17,7 +18,6 @@ thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
 
   thrust::copy(random_input.cbegin(), random_input.cend(), keys.begin());
   thrust::sort(keys.begin(), keys.end());
-  return keys;
 }
 
 template <typename T>

--- a/benches/thrust/fill/basic.cu
+++ b/benches/thrust/fill/basic.cu
@@ -1,0 +1,33 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/fill.h>
+
+// This benchmark can be also considered as parallel_for benchmark
+template <typename T>
+static void basic(nvbench::state &state,
+                  nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements);
+  thrust::device_vector<T> output(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+
+    thrust::fill(policy, output.begin(), output.end(), T{});
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types))
+.set_name("thrust::fill")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2));

--- a/benches/thrust/fill/basic.cu
+++ b/benches/thrust/fill/basic.cu
@@ -1,6 +1,7 @@
 #include <nvbench/nvbench.cuh>
 
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 
 // This benchmark can be also considered as parallel_for benchmark

--- a/benches/thrust/inclusive_scan/by_key.cu
+++ b/benches/thrust/inclusive_scan/by_key.cu
@@ -44,7 +44,7 @@ void by_key(nvbench::state &state, nvbench::type_list<T>)
 
   state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
     auto policy = thrust::device.on(launch.get_stream());
-    thrust::exclusive_scan_by_key(policy,
+    thrust::inclusive_scan_by_key(policy,
                                   keys.cbegin(),
                                   keys.cend(),
                                   in_values.begin(),
@@ -58,6 +58,6 @@ using types = nvbench::type_list<nvbench::int8_t,
                                  nvbench::float32_t,
                                  nvbench::float64_t>;
 NVBENCH_BENCH_TYPES(by_key, NVBENCH_TYPE_AXES(types))
-  .set_name("thrust::exclusive_scan_by_key")
+  .set_name("thrust::inclusive_scan_by_key")
   .add_int64_power_of_two_axis("Elements", nvbench::range(16, 30, 2))
   .add_string_axis("Pattern", {"single", "random"});

--- a/benches/thrust/inclusive_scan/by_key.cu
+++ b/benches/thrust/inclusive_scan/by_key.cu
@@ -1,12 +1,13 @@
 #include <nvbench/nvbench.cuh>
 
 #include <thrust/device_vector.h>
+#include <thrust/sort.h>
 #include <thrust/scan.h>
 
 #include <tbm/range_generator.cuh>
 
 template <typename T>
-thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
+void gen_keys(thrust::device_vector<T> &keys)
 {
   std::size_t elements = keys.size();
 
@@ -17,7 +18,6 @@ thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
 
   thrust::copy(random_input.cbegin(), random_input.cend(), keys.begin());
   thrust::sort(keys.begin(), keys.end());
-  return keys;
 }
 
 template <typename T>

--- a/benches/thrust/inner_product/basic.cu
+++ b/benches/thrust/inner_product/basic.cu
@@ -1,0 +1,35 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/inner_product.h>
+
+template <typename T>
+static void basic(nvbench::state &state,
+                  nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> lhs(elements);
+  thrust::device_vector<T> rhs(elements);
+
+  state.add_element_count(elements);
+  state.collect_dram_throughput();
+  state.collect_loads_efficiency();
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+
+    thrust::inner_product(policy, lhs.begin(), lhs.end(), rhs.begin(), T{});
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t,
+                                 nvbench::float32_t,
+                                 nvbench::float64_t>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::inner_product")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2));

--- a/benches/thrust/inner_product/basic.cu
+++ b/benches/thrust/inner_product/basic.cu
@@ -1,7 +1,9 @@
 #include <nvbench/nvbench.cuh>
 
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 #include <thrust/inner_product.h>
+#include <thrust/sort.h>
 
 template <typename T>
 static void basic(nvbench::state &state,

--- a/benches/thrust/merge/basic.cu
+++ b/benches/thrust/merge/basic.cu
@@ -1,0 +1,95 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/merge.h>
+
+#include <tbm/range_generator.cuh>
+
+template <typename T>
+void merge(nvbench::state &state,
+           nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto sets_size_ratio =
+    static_cast<std::size_t>(state.get_int64("InputsSizeRatio"));
+  const auto elements_in_first_input = static_cast<std::size_t>(
+    static_cast<double>(sets_size_ratio * elements) / 100.0f);
+  const auto elements_in_second_input = elements - elements_in_first_input;
+
+  thrust::device_vector<T> first_input(elements_in_first_input);
+  thrust::device_vector<T> second_input(elements_in_second_input);
+  thrust::device_vector<T> result(elements);
+
+
+  const auto pattern = state.get_string("Pattern");
+  if (pattern == "order")
+  {
+    thrust::fill(first_input.begin(), first_input.end(), T{0});
+    thrust::fill(second_input.begin(), second_input.end(), T{1});
+  }
+  else if (pattern == "match")
+  {
+    if (elements_in_first_input > elements_in_second_input)
+    {
+      thrust::sequence(first_input.begin(), first_input.end());
+      thrust::sort(first_input.begin(), first_input.end());
+      thrust::copy_n(first_input.begin(),
+                     elements_in_second_input,
+                     second_input.begin());
+    }
+    else
+    {
+      thrust::sequence(second_input.begin(), second_input.end());
+      thrust::sort(second_input.begin(), second_input.end());
+      thrust::copy_n(second_input.begin(),
+                     elements_in_first_input,
+                     first_input.begin());
+    }
+  }
+  else if (pattern == "random")
+  {
+    auto random_input =
+      tbm::make_range_generator<T,
+                                tbm::iterator_style::pointer,
+                                tbm::data_pattern::random>(elements);
+
+    thrust::copy(random_input.cbegin(),
+                 random_input.cbegin() + elements_in_first_input,
+                 first_input.begin());
+
+    thrust::copy(random_input.cbegin() + elements_in_first_input,
+                 random_input.cend(),
+                 second_input.begin());
+
+    thrust::sort(first_input.begin(), first_input.end());
+    thrust::sort(second_input.begin(), second_input.end());
+  }
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    const auto policy = thrust::device.on(launch.get_stream());
+
+    thrust::merge(policy,
+                  first_input.begin(),
+                  first_input.end(),
+                  second_input.begin(),
+                  second_input.end(),
+                  result.begin());
+  });
+}
+
+using types = nvbench::type_list<nvbench::int8_t,
+                                 nvbench::int16_t,
+                                 nvbench::int32_t,
+                                 nvbench::int64_t>;
+
+NVBENCH_BENCH_TYPES(merge, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::merge")
+  .add_int64_axis("InputsSizeRatio", nvbench::range(1, 100, 24))
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 30, 2))
+  .add_string_axis("Pattern", {"order", "match", "random"});

--- a/benches/thrust/merge/basic.cu
+++ b/benches/thrust/merge/basic.cu
@@ -3,6 +3,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/random.h>
 #include <thrust/sequence.h>
+#include <thrust/sort.h>
 #include <thrust/merge.h>
 
 #include <tbm/range_generator.cuh>

--- a/benches/thrust/partition/basic.cu
+++ b/benches/thrust/partition/basic.cu
@@ -1,0 +1,169 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/partition.h>
+
+#include <tbm/range_generator.cuh>
+
+enum class select_op_type
+{
+  greater_than_middle,
+  greater_than_zero,
+  even
+  // complex predicate case is covered
+  // in the thrust/partition/complex_predicate.cu
+};
+
+template <typename T>
+struct gt_select_op
+{
+  T m_val {};
+
+  explicit gt_select_op(T val)
+      : m_val(val)
+  {}
+
+  __device__ bool operator()(const T& val)
+  {
+    return val > m_val;
+  }
+};
+
+template <typename T>
+struct even_select_op
+{
+  __device__ bool operator()(const T& val)
+  {
+    return (val % 2) == 0;
+  }
+};
+
+template <select_op_type op_type>
+struct op_construction_helper;
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_middle>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(T elements)
+  {
+    return gt_select_op<T>{static_cast<T>(elements / 2)};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_zero>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(int /* elements */)
+  {
+    return gt_select_op<T>{T{}};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::even>
+{
+  template <typename T>
+  static even_select_op<T> create_select_op(int /* elements */)
+  {
+    return even_select_op<T>{};
+  }
+};
+
+template <typename T, select_op_type SelectOpType, tbm::data_pattern Pattern>
+static void basic(nvbench::state &state,
+                  nvbench::type_list<T,
+                                     nvbench::enum_type<SelectOpType>,
+                                     nvbench::enum_type<Pattern>>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  auto input =
+    tbm::make_range_generator<T, tbm::iterator_style::pointer, Pattern>(
+      elements);
+
+  thrust::device_vector<T> output(elements);
+
+  auto select_op =
+    op_construction_helper<SelectOpType>::template create_select_op<T>(
+      elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads(input.get_allocation_size());
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+
+    /*
+     * Partition allocates temporary storage and copies the input data into it.
+     * This allocation obscures the performance of the partition algorithm.
+     * That's the main reason to benchmark partition_copy instead of partition.
+     */
+    thrust::partition_copy(policy,
+                           input.cbegin(),
+                           input.cend(),
+                           output.begin(),
+                           thrust::make_reverse_iterator(output.begin() +
+                                                         elements),
+                           select_op);
+  });
+}
+
+// Column names for type axes:
+inline std::vector<std::string> select_if_type_axis_names()
+{
+  return {"T", "Op", "Pattern"};
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;
+
+using ops = nvbench::enum_type_list<select_op_type::greater_than_middle,
+                                    select_op_type::greater_than_zero,
+                                    select_op_type::even>;
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  select_op_type,
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Mid";
+      case select_op_type::greater_than_zero:
+        return "Zero";
+      case select_op_type::even:
+        return "Even";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  },
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Return true for elements > Elements/2";
+      case select_op_type::greater_than_zero:
+        return "Return true for all elements";
+      case select_op_type::even:
+        return "Return true for even elements";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  })
+
+using all_input_data_patterns =
+  nvbench::enum_type_list<tbm::data_pattern::sequence,
+                          tbm::data_pattern::constant,
+                          tbm::data_pattern::random>;
+
+NVBENCH_BENCH_TYPES(basic,
+                    NVBENCH_TYPE_AXES(types, ops, all_input_data_patterns))
+  .set_name("thrust::partition")
+  .set_type_axes_names(select_if_type_axis_names())
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2));

--- a/benches/thrust/partition/basic.cu
+++ b/benches/thrust/partition/basic.cu
@@ -14,6 +14,37 @@ enum class select_op_type
   // in the thrust/partition/complex_predicate.cu
 };
 
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  select_op_type,
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Mid";
+      case select_op_type::greater_than_zero:
+        return "Zero";
+      case select_op_type::even:
+        return "Even";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  },
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Return true for elements > Elements/2";
+      case select_op_type::greater_than_zero:
+        return "Return true for all elements";
+      case select_op_type::even:
+        return "Return true for even elements";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  })
+
 template <typename T>
 struct gt_select_op
 {
@@ -125,37 +156,6 @@ using types = nvbench::type_list<nvbench::uint8_t,
 using ops = nvbench::enum_type_list<select_op_type::greater_than_middle,
                                     select_op_type::greater_than_zero,
                                     select_op_type::even>;
-
-NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
-  select_op_type,
-  [](select_op_type select_op) {
-    switch (select_op)
-    {
-      case select_op_type::greater_than_middle:
-        return "Mid";
-      case select_op_type::greater_than_zero:
-        return "Zero";
-      case select_op_type::even:
-        return "Even";
-      default:
-        break;
-    }
-    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
-  },
-  [](select_op_type select_op) {
-    switch (select_op)
-    {
-      case select_op_type::greater_than_middle:
-        return "Return true for elements > Elements/2";
-      case select_op_type::greater_than_zero:
-        return "Return true for all elements";
-      case select_op_type::even:
-        return "Return true for even elements";
-      default:
-        break;
-    }
-    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
-  })
 
 using all_input_data_patterns =
   nvbench::enum_type_list<tbm::data_pattern::sequence,

--- a/benches/thrust/partition/complex_predicate.cu
+++ b/benches/thrust/partition/complex_predicate.cu
@@ -1,12 +1,7 @@
 #include <nvbench/nvbench.cuh>
 
-#include <thrust/count.h>
 #include <thrust/device_vector.h>
-#include <thrust/execution_policy.h>
-#include <thrust/sequence.h>
-// Why is this in detail?
-#include <thrust/detail/raw_pointer_cast.h>
-#include <cub/device/device_select.cuh>
+#include <thrust/partition.h>
 
 #include <tbm/range_generator.cuh>
 
@@ -60,37 +55,27 @@ static void basic(nvbench::state &state,
       elements);
 
   thrust::device_vector<T> output(elements);
-  thrust::device_vector<T> num_selected(1);
-
   complex_select_op<T, OperationsCount> select_op{0.42f};
-
-  auto selected_elements =
-    thrust::count_if(thrust::device, input.cbegin(), input.cend(), select_op);
 
   state.add_element_count(elements);
   state.add_global_memory_reads(input.get_allocation_size());
-  state.add_global_memory_writes<T>(selected_elements);
+  state.add_global_memory_writes<T>(elements);
 
-  size_t tmp_size;
-  cub::DeviceSelect::If(nullptr,
-                        tmp_size,
-                        input.cbegin(),
-                        thrust::raw_pointer_cast(output.data()),
-                        thrust::raw_pointer_cast(num_selected.data()),
-                        elements,
-                        select_op);
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
 
-  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size);
-
-  state.exec([&](nvbench::launch &launch) {
-    std::size_t temp_size = tmp.size(); // need an lvalue
-    cub::DeviceSelect::If(thrust::raw_pointer_cast(tmp.data()),
-                          temp_size,
-                          input.cbegin(),
-                          thrust::raw_pointer_cast(output.data()),
-                          thrust::raw_pointer_cast(num_selected.data()),
-                          elements,
-                          select_op);
+    /*
+     * Partition allocates temporary storage and copies the input data into it.
+     * This allocation obscures the performance of the partition algorithm.
+     * That's the main reason to benchmark partition_copy instead of partition.
+     */
+    thrust::partition_copy(policy,
+                           input.cbegin(),
+                           input.cend(),
+                           output.begin(),
+                           thrust::make_reverse_iterator(output.begin() +
+                                                         elements),
+                           select_op);
   });
 }
 
@@ -103,7 +88,7 @@ inline std::vector<std::string> select_if_type_axis_names()
 using types =
   nvbench::type_list<nvbench::float32_t>;
 
-using ops = nvbench::enum_type_list<128>;
+using ops = nvbench::enum_type_list<64>;
 
 using all_input_data_patterns =
   nvbench::enum_type_list<tbm::data_pattern::sequence,
@@ -112,6 +97,6 @@ using all_input_data_patterns =
 
 NVBENCH_BENCH_TYPES(basic,
                     NVBENCH_TYPE_AXES(types, ops, all_input_data_patterns))
-  .set_name("cub::DeviceSelect::If (complex predicate)")
+  .set_name("thrust::partition (complex predicate)")
   .set_type_axes_names(select_if_type_axis_names())
   .add_int64_power_of_two_axis("Elements", nvbench::range(22, 28, 2));

--- a/benches/thrust/partition/stencil.cu
+++ b/benches/thrust/partition/stencil.cu
@@ -1,0 +1,172 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/partition.h>
+
+#include <tbm/range_generator.cuh>
+
+enum class select_op_type
+{
+  greater_than_middle,
+  greater_than_zero,
+  even
+  // complex predicate case is covered
+  // in the thrust/partition/complex_predicate.cu
+};
+
+template <typename T>
+struct gt_select_op
+{
+  T m_val {};
+
+  explicit gt_select_op(T val)
+      : m_val(val)
+  {}
+
+  __device__ bool operator()(const T& val)
+  {
+    return val > m_val;
+  }
+};
+
+template <typename T>
+struct even_select_op
+{
+  __device__ bool operator()(const T& val)
+  {
+    return (val % 2) == 0;
+  }
+};
+
+template <select_op_type op_type>
+struct op_construction_helper;
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_middle>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(T elements)
+  {
+    return gt_select_op<T>{static_cast<T>(elements / 2)};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_zero>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(int /* elements */)
+  {
+    return gt_select_op<T>{T{}};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::even>
+{
+  template <typename T>
+  static even_select_op<T> create_select_op(int /* elements */)
+  {
+    return even_select_op<T>{};
+  }
+};
+
+template <typename T, select_op_type SelectOpType, tbm::data_pattern Pattern>
+static void basic(nvbench::state &state,
+                  nvbench::type_list<T,
+                                     nvbench::enum_type<SelectOpType>,
+                                     nvbench::enum_type<Pattern>>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  auto stencil =
+    tbm::make_range_generator<T, tbm::iterator_style::pointer, Pattern>(
+      elements);
+
+  thrust::device_vector<T> input(elements);
+  thrust::device_vector<T> output(elements);
+
+  auto select_op =
+    op_construction_helper<SelectOpType>::template create_select_op<T>(
+      elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads(stencil.get_allocation_size() +
+                                elements * sizeof(T));
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+
+    /*
+     * Partition allocates temporary storage and copies the input data into it.
+     * This allocation obscures the performance of the partition algorithm.
+     * That's the main reason to benchmark partition_copy instead of partition.
+     */
+    thrust::partition_copy(policy,
+                           input.cbegin(),
+                           input.cend(),
+                           stencil.cbegin(),
+                           output.begin(),
+                           thrust::make_reverse_iterator(output.begin() +
+                                                         elements),
+                           select_op);
+  });
+}
+
+// Column names for type axes:
+inline std::vector<std::string> select_if_type_axis_names()
+{
+  return {"T", "Op", "Pattern"};
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;
+
+using ops = nvbench::enum_type_list<select_op_type::greater_than_middle,
+                                    select_op_type::greater_than_zero,
+                                    select_op_type::even>;
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  select_op_type,
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Mid";
+      case select_op_type::greater_than_zero:
+        return "Zero";
+      case select_op_type::even:
+        return "Even";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  },
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Return true for elements > Elements/2";
+      case select_op_type::greater_than_zero:
+        return "Return true for all elements";
+      case select_op_type::even:
+        return "Return true for even elements";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  })
+
+using all_input_data_patterns =
+  nvbench::enum_type_list<tbm::data_pattern::sequence,
+                          tbm::data_pattern::constant,
+                          tbm::data_pattern::random>;
+
+NVBENCH_BENCH_TYPES(basic,
+                    NVBENCH_TYPE_AXES(types, ops, all_input_data_patterns))
+  .set_name("thrust::partition (stencil)")
+  .set_type_axes_names(select_if_type_axis_names())
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2));

--- a/benches/thrust/partition/stencil.cu
+++ b/benches/thrust/partition/stencil.cu
@@ -14,6 +14,37 @@ enum class select_op_type
   // in the thrust/partition/complex_predicate.cu
 };
 
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  select_op_type,
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Mid";
+      case select_op_type::greater_than_zero:
+        return "Zero";
+      case select_op_type::even:
+        return "Even";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  },
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Return true for elements > Elements/2";
+      case select_op_type::greater_than_zero:
+        return "Return true for all elements";
+      case select_op_type::even:
+        return "Return true for even elements";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  })
+
 template <typename T>
 struct gt_select_op
 {
@@ -128,37 +159,6 @@ using types = nvbench::type_list<nvbench::uint8_t,
 using ops = nvbench::enum_type_list<select_op_type::greater_than_middle,
                                     select_op_type::greater_than_zero,
                                     select_op_type::even>;
-
-NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
-  select_op_type,
-  [](select_op_type select_op) {
-    switch (select_op)
-    {
-      case select_op_type::greater_than_middle:
-        return "Mid";
-      case select_op_type::greater_than_zero:
-        return "Zero";
-      case select_op_type::even:
-        return "Even";
-      default:
-        break;
-    }
-    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
-  },
-  [](select_op_type select_op) {
-    switch (select_op)
-    {
-      case select_op_type::greater_than_middle:
-        return "Return true for elements > Elements/2";
-      case select_op_type::greater_than_zero:
-        return "Return true for all elements";
-      case select_op_type::even:
-        return "Return true for even elements";
-      default:
-        break;
-    }
-    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
-  })
 
 using all_input_data_patterns =
   nvbench::enum_type_list<tbm::data_pattern::sequence,

--- a/benches/thrust/reduce/by_key.cu
+++ b/benches/thrust/reduce/by_key.cu
@@ -1,0 +1,70 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/unique.h>
+#include <thrust/reduce.h>
+#include <thrust/sequence.h>
+
+#include <tbm/range_generator.cuh>
+
+template <typename T>
+thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
+{
+  std::size_t elements = keys.size();
+
+  auto random_input =
+    tbm::make_range_generator<T,
+                              tbm::iterator_style::pointer,
+                              tbm::data_pattern::random>(elements);
+
+  thrust::copy(random_input.cbegin(), random_input.cend(), keys.begin());
+  thrust::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+template <typename T>
+void by_key(nvbench::state &state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+  thrust::device_vector<T> in_keys(elements);
+  thrust::device_vector<T> in_values(elements);
+
+  const auto pattern = state.get_string("Pattern");
+  if (pattern == "single")
+  {
+    // in_keys is filled with 0
+  }
+  else if (pattern == "random")
+  {
+    gen_keys(in_keys);
+  }
+
+  thrust::device_vector<T> out_values(elements);
+  thrust::device_vector<T> out_keys = in_keys;
+
+  const std::size_t unique_keys =
+    thrust::distance(out_keys.begin(),
+                     thrust::unique(out_keys.begin(), out_keys.end()));
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(2 * elements, "Size");
+  state.add_global_memory_writes<T>(2 * unique_keys);
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    auto policy = thrust::device.on(launch.get_stream());
+
+    thrust::reduce_by_key(policy,
+                          in_keys.begin(),
+                          in_keys.end(),
+                          in_values.begin(),
+                          out_keys.begin(),
+                          out_values.begin());
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint32_t>;
+
+NVBENCH_BENCH_TYPES(by_key, NVBENCH_TYPE_AXES(types))
+  .set_name("thrust::reduce_by_key")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 29, 2))
+  .add_string_axis("Pattern", {"single", "random"});

--- a/benches/thrust/reduce/by_key.cu
+++ b/benches/thrust/reduce/by_key.cu
@@ -2,13 +2,14 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/unique.h>
+#include <thrust/sort.h>
 #include <thrust/reduce.h>
 #include <thrust/sequence.h>
 
 #include <tbm/range_generator.cuh>
 
 template <typename T>
-thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
+void gen_keys(thrust::device_vector<T> &keys)
 {
   std::size_t elements = keys.size();
 
@@ -19,7 +20,6 @@ thrust::device_vector<T> gen_keys(thrust::device_vector<T> keys)
 
   thrust::copy(random_input.cbegin(), random_input.cend(), keys.begin());
   thrust::sort(keys.begin(), keys.end());
-  return keys;
 }
 
 template <typename T>

--- a/benches/thrust/set_operations/difference.cu
+++ b/benches/thrust/set_operations/difference.cu
@@ -1,0 +1,30 @@
+#include "set_operations.cuh"
+
+struct Difference
+{
+  Difference(std::size_t, std::size_t) {}
+
+  template <typename DerivedPolicy,
+            typename InputIterator1,
+            typename InputIterator2,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator result) const
+  {
+    thrust::set_difference(exec, first1, last1, first2, last2, result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(Difference, "Difference", "");
+
+using operations = nvbench::type_list<Difference>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::set_difference")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/set_operations/difference_by_key.cu
+++ b/benches/thrust/set_operations/difference_by_key.cu
@@ -1,0 +1,60 @@
+#include "set_operations.cuh"
+
+#include <thrust/device_vector.h>
+#include <type_traits>
+
+
+struct DifferenceByKey
+{
+  thrust::device_vector<std::uint8_t> A_values;
+  thrust::device_vector<std::uint8_t> values_result;
+
+  DifferenceByKey(std::size_t A_bytes,
+                  std::size_t)
+    : A_values(A_bytes)
+    , values_result(A_bytes)
+  {
+
+  }
+
+  template <typename DerivedPolicy,
+            typename InputIterator1,
+            typename InputIterator2,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator keys_result)
+  {
+    using KeyT = typename std::iterator_traits<InputIterator1>::value_type;
+    using ValueT = KeyT;
+
+    auto d_A_values = reinterpret_cast<const ValueT *>(
+      thrust::raw_pointer_cast(A_values.data()));
+    auto d_values_result = reinterpret_cast<ValueT *>(
+      thrust::raw_pointer_cast(values_result.data()));
+
+    // B values aren't needed (issues #1493)
+    thrust::set_difference_by_key(exec,
+                                  first1,
+                                  last1,
+                                  first2,
+                                  last2,
+                                  d_A_values,
+                                  thrust::make_counting_iterator(ValueT{}),
+                                  keys_result,
+                                  d_values_result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(DifferenceByKey, "DifferenceByKey", "");
+
+using operations = nvbench::type_list<DifferenceByKey>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::set_difference_by_key")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/set_operations/intersection.cu
+++ b/benches/thrust/set_operations/intersection.cu
@@ -1,0 +1,30 @@
+#include "set_operations.cuh"
+
+struct Intersection
+{
+  Intersection(std::size_t, std::size_t) {}
+
+  template <typename DerivedPolicy,
+    typename InputIterator1,
+    typename InputIterator2,
+    typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator result) const
+  {
+    thrust::set_intersection(exec, first1, last1, first2, last2, result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(Intersection, "Intersection", "");
+
+using operations = nvbench::type_list<Intersection>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+.set_name("thrust::set_intersection")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/set_operations/intersection_by_key.cu
+++ b/benches/thrust/set_operations/intersection_by_key.cu
@@ -1,0 +1,56 @@
+#include "set_operations.cuh"
+
+#include <thrust/device_vector.h>
+#include <type_traits>
+
+
+struct IntersectionByKey
+{
+  thrust::device_vector<std::uint8_t> A_values;
+  thrust::device_vector<std::uint8_t> values_result;
+
+  IntersectionByKey(std::size_t A_bytes,
+                    std::size_t /* B_bytes */)
+      : A_values(A_bytes)
+      , values_result(A_bytes)
+  {}
+
+  template <typename DerivedPolicy,
+            typename InputIterator1,
+            typename InputIterator2,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator keys_result)
+  {
+    using KeyT = typename std::iterator_traits<InputIterator1>::value_type;
+    using ValueT = KeyT;
+
+    auto d_A_values = reinterpret_cast<const ValueT *>(
+      thrust::raw_pointer_cast(A_values.data()));
+    auto d_values_result = reinterpret_cast<ValueT *>(
+      thrust::raw_pointer_cast(values_result.data()));
+
+    thrust::set_intersection_by_key(exec,
+                                    first1,
+                                    last1,
+                                    first2,
+                                    last2,
+                                    d_A_values,
+                                    keys_result,
+                                    d_values_result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(IntersectionByKey, "IntersectionByKey", "");
+
+using operations = nvbench::type_list<IntersectionByKey>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::set_intersection_by_key")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/set_operations/set_operations.cuh
+++ b/benches/thrust/set_operations/set_operations.cuh
@@ -1,0 +1,98 @@
+#include <nvbench/nvbench.cuh>
+
+#include <type_traits>
+
+#include <thrust/set_operations.h>
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <tbm/range_generator.cuh>
+
+
+template <typename T>
+void gen_full_input(thrust::device_vector<T> &large,
+                    thrust::device_vector<T> &small)
+{
+  thrust::sequence(large.begin(), large.end());
+  thrust::sort(large.begin(), large.end());
+  thrust::copy_n(large.begin(), small.size(), small.begin());
+}
+
+
+template <typename T,
+          typename OperationT>
+void basic(nvbench::state &state, nvbench::type_list<T, OperationT>)
+{
+  const auto elements =
+    static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto sets_size_ratio =
+    static_cast<std::size_t>(state.get_int64("SetsSizeRatio"));
+  const auto elements_in_B = static_cast<std::size_t>(
+    static_cast<double>(sets_size_ratio * elements) / 100.0f);
+  const auto elements_in_A = elements - elements_in_B;
+
+  OperationT operation{elements_in_A * sizeof(T), elements_in_B * sizeof(T)};
+
+  thrust::device_vector<T> input_A(elements_in_A);
+  thrust::device_vector<T> input_B(elements_in_B);
+
+  state.add_element_count(elements);
+
+  thrust::device_vector<T> result(elements);
+
+  const auto pattern = state.get_string("Pattern");
+  if (pattern == "full")
+  {
+    if (elements_in_A > elements_in_B)
+    {
+      gen_full_input(input_A, input_B);
+    }
+    else
+    {
+      gen_full_input(input_B, input_A);
+    }
+  }
+  else if (pattern == "empty")
+  {
+    thrust::fill(input_A.begin(), input_A.end(), T{2});
+    thrust::fill(input_B.begin(), input_B.end(), T{4});
+  }
+  else if (pattern == "random")
+  {
+    auto random_input =
+      tbm::make_range_generator<T,
+                                tbm::iterator_style::pointer,
+                                tbm::data_pattern::random>(elements);
+
+    thrust::copy(random_input.cbegin(),
+                 random_input.cbegin() + elements_in_A,
+                 input_A.begin());
+
+    thrust::copy(random_input.cbegin() + elements_in_A,
+                 random_input.cend(),
+                 input_B.begin());
+
+    thrust::sort(input_A.begin(), input_A.end());
+    thrust::sort(input_B.begin(), input_B.end());
+  }
+
+  state.collect_dram_throughput();
+  state.collect_loads_efficiency();
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    const auto policy = thrust::device.on(launch.get_stream());
+
+    operation(policy,
+              input_A.begin(),
+              input_A.end(),
+              input_B.begin(),
+              input_B.end(),
+              result.begin());
+  });
+}
+
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;

--- a/benches/thrust/set_operations/set_operations.cuh
+++ b/benches/thrust/set_operations/set_operations.cuh
@@ -5,6 +5,7 @@
 #include <thrust/set_operations.h>
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
+#include <thrust/sort.h>
 
 #include <tbm/range_generator.cuh>
 

--- a/benches/thrust/set_operations/symmetric_difference.cu
+++ b/benches/thrust/set_operations/symmetric_difference.cu
@@ -1,0 +1,30 @@
+#include "set_operations.cuh"
+
+struct SymmetricDifference
+{
+  SymmetricDifference(std::size_t, std::size_t) {}
+
+  template <typename DerivedPolicy,
+            typename InputIterator1,
+            typename InputIterator2,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator result) const
+  {
+    thrust::set_symmetric_difference(exec, first1, last1, first2, last2, result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(SymmetricDifference, "SymmetricDifference", "");
+
+using operations = nvbench::type_list<SymmetricDifference>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::set_symmetric_difference")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/set_operations/symmetric_difference_by_key.cu
+++ b/benches/thrust/set_operations/symmetric_difference_by_key.cu
@@ -1,0 +1,61 @@
+#include "set_operations.cuh"
+
+#include <thrust/device_vector.h>
+#include <type_traits>
+
+struct SymmetricDifferenceByKey
+{
+  thrust::device_vector<std::uint8_t> A_values;
+  thrust::device_vector<std::uint8_t> B_values;
+  thrust::device_vector<std::uint8_t> values_result;
+
+  SymmetricDifferenceByKey(std::size_t A_bytes, std::size_t B_bytes)
+      : A_values(A_bytes)
+      , B_values(B_bytes)
+      , values_result(A_bytes + B_bytes)
+  {}
+
+  template <typename DerivedPolicy,
+            typename InputIterator1,
+            typename InputIterator2,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator keys_result)
+  {
+    using KeyT   = typename std::iterator_traits<InputIterator1>::value_type;
+    using ValueT = KeyT;
+
+    auto d_A_values = reinterpret_cast<const ValueT *>(
+      thrust::raw_pointer_cast(A_values.data()));
+    auto d_B_values = reinterpret_cast<const ValueT *>(
+      thrust::raw_pointer_cast(B_values.data()));
+    auto d_values_result = reinterpret_cast<ValueT *>(
+      thrust::raw_pointer_cast(values_result.data()));
+
+    thrust::set_symmetric_difference_by_key(exec,
+                                            first1,
+                                            last1,
+                                            first2,
+                                            last2,
+                                            d_A_values,
+                                            d_B_values,
+                                            keys_result,
+                                            d_values_result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(SymmetricDifferenceByKey,
+                             "SymmetricDifferenceByKey",
+                             "");
+
+using operations = nvbench::type_list<SymmetricDifferenceByKey>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::set_intersection_by_key")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/set_operations/union.cu
+++ b/benches/thrust/set_operations/union.cu
@@ -1,0 +1,30 @@
+#include "set_operations.cuh"
+
+struct Union
+{
+  Union(std::size_t, std::size_t) {}
+
+  template <typename DerivedPolicy,
+            typename InputIterator1,
+            typename InputIterator2,
+            typename OutputIterator>
+  __host__ __device__ OutputIterator
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator result) const
+  {
+    return thrust::set_union(exec, first1, last1, first2, last2, result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(Union, "Union", "");
+
+using operations = nvbench::type_list<Union>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::set_union")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/set_operations/union_by_key.cu
+++ b/benches/thrust/set_operations/union_by_key.cu
@@ -1,0 +1,63 @@
+#include "set_operations.cuh"
+
+#include <thrust/device_vector.h>
+#include <type_traits>
+
+
+struct UnionByKey
+{
+  thrust::device_vector<std::uint8_t> A_values;
+  thrust::device_vector<std::uint8_t> B_values;
+  thrust::device_vector<std::uint8_t> values_result;
+
+  UnionByKey(std::size_t A_bytes,
+             std::size_t B_bytes)
+    : A_values(A_bytes)
+    , B_values(B_bytes)
+    , values_result(A_bytes + B_bytes)
+  {
+
+  }
+
+  template <typename DerivedPolicy,
+            typename InputIterator1,
+            typename InputIterator2,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator1 first1,
+             InputIterator1 last1,
+             InputIterator2 first2,
+             InputIterator2 last2,
+             OutputIterator keys_result)
+  {
+    using KeyT = typename std::iterator_traits<InputIterator1>::value_type;
+    using ValueT = KeyT;
+
+    auto d_A_values = reinterpret_cast<const ValueT *>(
+      thrust::raw_pointer_cast(A_values.data()));
+    auto d_B_values = reinterpret_cast<const ValueT *>(
+      thrust::raw_pointer_cast(B_values.data()));
+    auto d_values_result = reinterpret_cast<ValueT *>(
+      thrust::raw_pointer_cast(values_result.data()));
+
+    thrust::set_union_by_key(exec,
+                             first1,
+                             last1,
+                             first2,
+                             last2,
+                             d_A_values,
+                             d_B_values,
+                             keys_result,
+                             d_values_result);
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(UnionByKey, "UnionByKey", "");
+
+using operations = nvbench::type_list<UnionByKey>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::set_difference_by_key")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_int64_axis("SetsSizeRatio", nvbench::range(1, 100, 24))
+  .add_string_axis("Pattern", {"full", "empty", "random"});

--- a/benches/thrust/unique/basic.cu
+++ b/benches/thrust/unique/basic.cu
@@ -1,0 +1,36 @@
+#include "unique.cuh"
+
+struct Unique
+{
+  Unique(std::size_t) {}
+
+  template <typename DerivedPolicy,
+            typename InputIterator,
+            typename OutputIterator>
+  void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator first,
+             InputIterator last,
+             OutputIterator result)
+  {
+    thrust::unique_copy(exec, first, last, result);
+  }
+
+  std::size_t extra_bytes_to_read()
+  {
+    return 0;
+  }
+
+  template <typename T>
+  std::size_t extra_bytes_to_write(std::size_t)
+  {
+    return 0;
+  }
+};
+
+using operations = nvbench::type_list<Unique>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::unique_copy")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_string_axis("Pattern", {"unique", "const", "random"});

--- a/benches/thrust/unique/by_key.cu
+++ b/benches/thrust/unique/by_key.cu
@@ -1,0 +1,57 @@
+#include "unique.cuh"
+
+#include <type_traits>
+
+struct UniqueByKey
+{
+  thrust::device_vector<std::uint8_t> in_values;
+  thrust::device_vector<std::uint8_t> out_values;
+
+  UniqueByKey(std::size_t bytes)
+      : in_values(bytes)
+      , out_values(bytes)
+  {}
+
+  std::size_t extra_bytes_to_read()
+  {
+    return in_values.size();
+  }
+
+  template <typename T>
+  std::size_t extra_bytes_to_write(std::size_t unique_elements)
+  {
+    return unique_elements * sizeof(T);
+  }
+
+  template <typename DerivedPolicy,
+            typename InputIterator,
+            typename OutputIterator>
+  void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             InputIterator first,
+             InputIterator last,
+             OutputIterator result)
+  {
+    using KeyT = typename std::iterator_traits<InputIterator>::value_type;
+    using ValueT = KeyT;
+
+    auto d_in_values =
+      reinterpret_cast<ValueT *>(thrust::raw_pointer_cast(in_values.data()));
+    auto d_out_values =
+      reinterpret_cast<ValueT *>(thrust::raw_pointer_cast(out_values.data()));
+
+    thrust::unique_by_key_copy(exec,
+                               first,
+                               last,
+                               d_in_values,
+                               result,
+                               d_out_values);
+  }
+};
+
+using operations = nvbench::type_list<UniqueByKey>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::unique_by_key_copy")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 2))
+  .add_string_axis("Pattern", {"unique", "const", "random"});

--- a/benches/thrust/unique/unique.cuh
+++ b/benches/thrust/unique/unique.cuh
@@ -1,0 +1,73 @@
+#include <nvbench/nvbench.cuh>
+
+#include <type_traits>
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/unique.h>
+
+#include <tbm/range_generator.cuh>
+
+template <typename T,
+          typename OperationT>
+void basic(nvbench::state &state, nvbench::type_list<T, OperationT>)
+{
+  const auto elements =
+    static_cast<std::size_t>(state.get_int64("Elements"));
+
+  OperationT operation{elements * sizeof(T)};
+
+  thrust::device_vector<T> input(elements);
+  thrust::device_vector<T> result(elements);
+
+  state.add_element_count(elements);
+
+  const auto pattern = state.get_string("Pattern");
+  if (pattern == "unique")
+  {
+    thrust::sequence(input.begin(), input.end());
+
+    if (elements > std::numeric_limits<T>::max())
+    {
+      thrust::sort(input.begin(), input.end());
+    }
+  }
+  else if (pattern == "const")
+  {
+    thrust::fill(input.begin(), input.end(), T{2});
+  }
+  else if (pattern == "random")
+  {
+    auto random_input =
+      tbm::make_range_generator<T,
+                                tbm::iterator_style::pointer,
+                                tbm::data_pattern::random>(elements);
+
+    thrust::copy(random_input.cbegin(), random_input.cend(), input.begin());
+    thrust::sort(input.begin(), input.end());
+  }
+
+  {
+    const std::size_t unique_items = thrust::distance(
+      result.begin(),
+      thrust::unique_copy(input.begin(), input.end(), result.begin()));
+
+    state.add_global_memory_reads<T>(elements);
+    state.add_global_memory_writes<T>(unique_items);
+
+    state.add_global_memory_reads(operation.extra_bytes_to_read());
+    state.add_global_memory_writes(
+      operation.template extra_bytes_to_write<T>(unique_items));
+  }
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    const auto policy = thrust::device.on(launch.get_stream());
+
+    operation(policy, input.begin(), input.end(), result.begin());
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;

--- a/benches/thrust/unique/unique.cuh
+++ b/benches/thrust/unique/unique.cuh
@@ -5,6 +5,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 #include <thrust/unique.h>
+#include <thrust/sort.h>
 
 #include <tbm/range_generator.cuh>
 

--- a/benches/thrust/vectorized_search/binary_search.cu
+++ b/benches/thrust/vectorized_search/binary_search.cu
@@ -1,0 +1,27 @@
+#include "search.cuh"
+
+struct BinaryBound
+{
+  template <typename DerivedPolicy,
+            typename ForwardIterator,
+            typename InputIterator,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             ForwardIterator first,
+             ForwardIterator last,
+             InputIterator values_first,
+             InputIterator values_last,
+             OutputIterator output)
+  {
+    thrust::binary_search(exec, first, last, values_first, values_last, output);
+  }
+};
+
+using operations = nvbench::type_list<BinaryBound>;
+
+NVBENCH_BENCH_TYPES(search, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::binary_search")
+  .add_int64_axis("NeedlesRatio", nvbench::range(1, 100, 24))
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 26, 2))
+  .add_string_axis("Pattern", {"sequence", "uniform", "random"});

--- a/benches/thrust/vectorized_search/lower_bound.cu
+++ b/benches/thrust/vectorized_search/lower_bound.cu
@@ -1,0 +1,27 @@
+#include "search.cuh"
+
+struct LowerBound
+{
+  template <typename DerivedPolicy,
+            typename ForwardIterator,
+            typename InputIterator,
+            typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             ForwardIterator first,
+             ForwardIterator last,
+             InputIterator values_first,
+             InputIterator values_last,
+             OutputIterator output)
+  {
+    thrust::lower_bound(exec, first, last, values_first, values_last, output);
+  }
+};
+
+using operations = nvbench::type_list<LowerBound>;
+
+NVBENCH_BENCH_TYPES(search, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::lower_bound")
+  .add_int64_axis("NeedlesRatio", nvbench::range(1, 100, 24))
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 26, 2))
+  .add_string_axis("Pattern", {"sequence", "uniform", "random"});

--- a/benches/thrust/vectorized_search/search.cuh
+++ b/benches/thrust/vectorized_search/search.cuh
@@ -79,4 +79,7 @@ void search(nvbench::state &state,
   });
 }
 
-using types = nvbench::type_list<nvbench::uint32_t>;
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;

--- a/benches/thrust/vectorized_search/search.cuh
+++ b/benches/thrust/vectorized_search/search.cuh
@@ -1,0 +1,82 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+
+#include <tbm/range_generator.cuh>
+
+std::size_t get_needles_num(std::size_t haystack_size,
+                            std::size_t needles_ratio)
+{
+  return needles_ratio *
+         static_cast<std::size_t>(static_cast<double>(haystack_size) / 100.0);
+}
+
+template <typename T>
+thrust::device_vector<T> gen_haystack(std::size_t elements)
+{
+  auto random_input =
+    tbm::make_range_generator<T,
+                              tbm::iterator_style::pointer,
+                              tbm::data_pattern::random>(elements);
+
+  thrust::device_vector<T> haystack(random_input.cbegin(), random_input.cend());
+  thrust::sort(haystack.begin(), haystack.end());
+  return haystack;
+}
+
+template <typename T,
+          typename OperationT>
+void search(nvbench::state &state,
+            nvbench::type_list<T, OperationT>)
+{
+  const auto haystack_size =
+    static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto needles_ratio =
+    static_cast<std::size_t>(state.get_int64("NeedlesRatio"));
+
+  const auto needles_num = get_needles_num(haystack_size, needles_ratio);
+
+  thrust::device_vector<T> haystack = gen_haystack<T>(haystack_size);
+  thrust::device_vector<std::size_t> result(needles_num);
+  thrust::device_vector<T> needles(needles_num);
+
+  OperationT operation{};
+
+  const auto pattern = state.get_string("Pattern");
+  if (pattern == "sequence")
+  {
+    thrust::sequence(needles.begin(), needles.end());
+  }
+  else if (pattern == "uniform")
+  {
+    const auto step = static_cast<T>(haystack_size / needles_num);
+    thrust::sequence(needles.begin(), needles.end(), T{}, step);
+  }
+  else if (pattern == "random")
+  {
+    needles = haystack;
+
+    thrust::default_random_engine re;
+    thrust::shuffle(needles.begin(), needles.end(), re);
+    needles.resize(needles_num);
+  }
+
+  state.collect_dram_throughput();
+  state.collect_loads_efficiency();
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    const auto policy = thrust::device.on(launch.get_stream());
+    operation(policy,
+              haystack.begin(),
+              haystack.end(),
+              needles.begin(),
+              needles.end(),
+              result.begin());
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint32_t>;

--- a/benches/thrust/vectorized_search/search.cuh
+++ b/benches/thrust/vectorized_search/search.cuh
@@ -2,9 +2,11 @@
 
 #include <thrust/binary_search.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 #include <thrust/random.h>
 #include <thrust/sequence.h>
 #include <thrust/shuffle.h>
+#include <thrust/sort.h>
 
 #include <tbm/range_generator.cuh>
 

--- a/benches/thrust/vectorized_search/upper_bound.cu
+++ b/benches/thrust/vectorized_search/upper_bound.cu
@@ -1,0 +1,27 @@
+#include "search.cuh"
+
+struct UpperBound
+{
+  template <typename DerivedPolicy,
+    typename ForwardIterator,
+    typename InputIterator,
+    typename OutputIterator>
+  __host__ __device__ void
+  operator()(const thrust::detail::execution_policy_base<DerivedPolicy> &exec,
+             ForwardIterator first,
+             ForwardIterator last,
+             InputIterator values_first,
+             InputIterator values_last,
+             OutputIterator output)
+  {
+    thrust::upper_bound(exec, first, last, values_first, values_last, output);
+  }
+};
+
+using operations = nvbench::type_list<UpperBound>;
+
+NVBENCH_BENCH_TYPES(search, NVBENCH_TYPE_AXES(types, operations))
+  .set_name("thrust::upper_bound")
+  .add_int64_axis("NeedlesRatio", nvbench::range(1, 100, 24))
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 26, 2))
+  .add_string_axis("Pattern", {"sequence", "uniform", "random"});


### PR DESCRIPTION
This PR relies on the [following PR](https://github.com/NVIDIA/nvbench/pull/29) and covers thrust algorithms with custom kernels:

- `adjacent_difference`
- `partition`
- `copy`
- `copy_if`
- set operations:
   - `set_difference`
   - `set_difference_by_key`
   - `set_intersection`
   - `set_intersection_by_key`
   - `set_symmetric_difference`
   - `set_symmetric_difference_by_key`
   - `set_union`
   - `set_union_by_key`
- `inclusive_scan_by_key`
- `exclusive_scan_by_key`
- `reduce_by_key`
- vectorized search:
   - `lower_bound`
   - `upper_bound`
   - `binary_search`
- `merge`
- `fill`
- `unique`
- `unique_by_key`
- `inner_product`

I've used the `copy` version of some algorithms so as not to benchmark internal memory allocation/copying. 