### PR TITLE
CUB core benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cmake-build-release
+cmake-build-debug
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # 3.18.3 fixed bugs in MSVC + CUDA + C++17 support
 cmake_minimum_required(VERSION 3.18.3)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
+
 # CXX needed for fmt
 project(thrust_benchmark CXX CUDA)
 

--- a/benches/cub/block/discontinuity/block_discontinuity.cuh
+++ b/benches/cub/block/discontinuity/block_discontinuity.cuh
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <nvbench/detail/throw.cuh>
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+// Why is this in detail?
+#include <thrust/detail/raw_pointer_cast.h>
+
+#include <cub/block/block_discontinuity.cuh>
+
+
+constexpr int iterations = 10;
+__constant__ int input_data[iterations];
+
+
+template <typename T,
+          int ItemsPerThread>
+__device__ void fill_thread_data(int pivot,
+                                 T (&thread_data)[ItemsPerThread],
+                                 const unsigned int linear_id)
+{
+  for (int i = 0; i < ItemsPerThread; i++)
+  {
+    thread_data[i] = pivot * static_cast<T>(linear_id + i);
+  }
+}
+
+
+template <typename T,
+          int ItemsPerThread>
+__device__ void do_not_optimize(int *output,
+                                T (&thread_data)[ItemsPerThread],
+                                const unsigned int linear_id)
+{
+  int count = 0;
+  for (int i = 0; i < ItemsPerThread; i++)
+  {
+    if (thread_data[i])
+    {
+      count++;
+    }
+  }
+
+  if (count > 42)
+  {
+    atomicAdd(output + linear_id, 1);
+  }
+}
+
+// This kernel is used to check that runtime of BlockDiscontinuity methods
+// exceeds wrapper overhead
+template <typename T, int ItemsPerThread>
+__global__ void kernel_reference(int *output)
+{
+  const unsigned int linear_id = threadIdx.x + blockIdx.x * blockDim.x;
+  T thread_data[ItemsPerThread];
+
+  for (int pivot: input_data)
+  {
+    fill_thread_data(pivot, thread_data, linear_id);
+    do_not_optimize(output, thread_data, linear_id);
+  }
+}
+
+template <typename T,
+          typename OperationType,
+          int ThreadsInBlock,
+          int ItemsPerThread>
+__global__ void kernel(int *output)
+{
+  const unsigned int linear_id = threadIdx.x + blockIdx.x * blockDim.x;
+
+  bool flags[ItemsPerThread];
+  T thread_data[ItemsPerThread];
+
+  using BlockDiscontinuity = cub::BlockDiscontinuity<T, ThreadsInBlock>;
+
+  __shared__ typename BlockDiscontinuity::TempStorage temp_storage;
+
+  BlockDiscontinuity discontinuity(temp_storage);
+
+  for (int pivot: input_data)
+  {
+    fill_thread_data(pivot, thread_data, linear_id);
+    OperationType()(discontinuity, flags, thread_data);
+    do_not_optimize(output, flags, linear_id);
+  }
+}
+
+template <typename T,
+          typename OperationType,
+          int ThreadsInBlock,
+          int ItemsPerThread>
+static void bench(nvbench::state &state,
+                  nvbench::type_list<T,
+                                     OperationType,
+                                     nvbench::enum_type<ThreadsInBlock>,
+                                     nvbench::enum_type<ItemsPerThread>>)
+{
+  const auto blocks_in_grid = 524288;
+
+  std::vector<int> h_data(iterations);
+  cudaMemcpyToSymbol(input_data, h_data.data(), sizeof(int) * iterations);
+
+  state.add_element_count(blocks_in_grid);
+  state.add_global_memory_reads<T>(blocks_in_grid);
+
+  const bool reference_mode = state.get_string("Mode") == "Reference";
+
+  state.exec([&](nvbench::launch &launch) {
+    /**
+     * Kernel below reads zeroes and performs BlockDiscontinuity operation.
+     * The result is only written if there are at least 42 heads within the
+     * result. Because the data is filled with zeroes, there is only one head.
+     * Therefore, there is no need in allocating output array. This trick is
+     * done to prevent the compiler from optimizing the code.
+     */
+    int *output = nullptr;
+
+    if (reference_mode)
+    {
+      kernel_reference<T, ItemsPerThread>
+        <<<blocks_in_grid, ThreadsInBlock>>>(output);
+    }
+    else
+    {
+      kernel<T, OperationType, ThreadsInBlock, ItemsPerThread>
+        <<<blocks_in_grid, ThreadsInBlock>>>(output);
+    }
+  });
+}
+
+inline std::vector<std::string> type_axis_names()
+{
+  return {"T", "Op", "ThreadsInBlock", "ItemsPerThread"};
+}
+
+using types = nvbench::type_list<nvbench::uint32_t, nvbench::uint64_t>;
+using threads_in_block = nvbench::enum_type_list<128, 512, 1024>;
+using items_per_thread = nvbench::enum_type_list<1, 4>;

--- a/benches/cub/block/discontinuity/flag_heads.cu
+++ b/benches/cub/block/discontinuity/flag_heads.cu
@@ -1,0 +1,26 @@
+#include "block_discontinuity.cuh"
+
+struct heads
+{
+  template <typename BlockDiscontinuity,
+            typename T,
+            int ItemsPerThread>
+  __device__ void operator()(BlockDiscontinuity &block_discontinuity,
+                             bool (&flags)[ItemsPerThread],
+                             T (&thread_data)[ItemsPerThread])
+  {
+    block_discontinuity.FlagHeads(flags, thread_data, cub::Inequality());
+  }
+};
+NVBENCH_DECLARE_TYPE_STRINGS(heads, "heads", "");
+
+using op = nvbench::type_list<heads>;
+
+NVBENCH_BENCH_TYPES(bench,
+                    NVBENCH_TYPE_AXES(types,
+                                      op,
+                                      threads_in_block,
+                                      items_per_thread))
+  .set_name("cub::BlockDiscontinuity::FlagHeads")
+  .set_type_axes_names(type_axis_names())
+  .add_string_axis("Mode", {"Reference", "Compute"});

--- a/benches/cub/device/partition/if.cu
+++ b/benches/cub/device/partition/if.cu
@@ -1,7 +1,8 @@
 #include <nvbench/nvbench.cuh>
 
+#include <thrust/execution_policy.h>
 #include <thrust/device_vector.h>
-#include <thrust/sequence.h>
+#include <thrust/count.h>
 // Why is this in detail?
 #include <thrust/detail/raw_pointer_cast.h>
 

--- a/benches/cub/device/partition/if.cu
+++ b/benches/cub/device/partition/if.cu
@@ -1,0 +1,171 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+// Why is this in detail?
+#include <thrust/detail/raw_pointer_cast.h>
+
+#include <cub/device/device_partition.cuh>
+
+#include <tbm/range_generator.cuh>
+
+enum class select_op_type
+{
+  greater_than_middle,
+  greater_than_zero,
+  even
+};
+
+template <typename T>
+struct gt_select_op
+{
+  T m_val{};
+
+  explicit gt_select_op(T val)
+      : m_val(val)
+  {}
+
+  __device__ bool operator()(const T &val) { return val > m_val; }
+};
+
+template <typename T>
+struct even_select_op
+{
+  __device__ bool operator()(const T &val) { return (val % 2) == 0; }
+};
+
+template <select_op_type op_type>
+struct op_construction_helper;
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_middle>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(T elements)
+  {
+    return gt_select_op<T>{elements / 2};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::greater_than_zero>
+{
+  template <typename T>
+  static gt_select_op<T> create_select_op(int /* elements */)
+  {
+    return gt_select_op<T>{T{}};
+  }
+};
+
+template <>
+struct op_construction_helper<select_op_type::even>
+{
+  template <typename T>
+  static even_select_op<T> create_select_op(int /* elements */)
+  {
+    return even_select_op<T>{};
+  }
+};
+
+template <typename T, select_op_type SelectOpType, tbm::data_pattern Pattern>
+static void basic(nvbench::state &state,
+                  nvbench::type_list<T,
+                                     nvbench::enum_type<SelectOpType>,
+                                     nvbench::enum_type<Pattern>>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  auto input =
+    tbm::make_range_generator<T, tbm::iterator_style::pointer, Pattern>(
+      elements);
+
+  thrust::device_vector<T> output(elements);
+  thrust::device_vector<T> num_selected(1);
+
+  auto select_op =
+    op_construction_helper<SelectOpType>::template create_select_op<T>(
+      elements);
+
+  auto selected_elements =
+    thrust::count_if(thrust::device, input.cbegin(), input.cend(), select_op);
+
+  size_t tmp_size;
+  cub::DevicePartition::If(nullptr,
+                           tmp_size,
+                           input.cbegin(),
+                           thrust::raw_pointer_cast(output.data()),
+                           thrust::raw_pointer_cast(num_selected.data()),
+                           elements,
+                           select_op);
+
+  thrust::device_vector<nvbench::uint8_t> tmp(tmp_size);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads(input.get_allocation_size());
+  state.add_global_memory_writes<T>(selected_elements);
+
+  state.exec([&](nvbench::launch &launch) {
+    std::size_t temp_size = tmp.size(); // need an lvalue
+    cub::DevicePartition::If(thrust::raw_pointer_cast(tmp.data()),
+                             temp_size,
+                             input.cbegin(),
+                             thrust::raw_pointer_cast(output.data()),
+                             thrust::raw_pointer_cast(num_selected.data()),
+                             elements,
+                             select_op);
+  });
+}
+
+// Column names for type axes:
+inline std::vector<std::string> select_if_type_axis_names()
+{
+  return {"T", "Op", "Pattern"};
+}
+
+using types = nvbench::type_list<nvbench::uint32_t, nvbench::uint64_t>;
+
+using ops = nvbench::enum_type_list<select_op_type::greater_than_middle,
+                                    select_op_type::greater_than_zero,
+                                    select_op_type::even>;
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  select_op_type,
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Mid";
+      case select_op_type::greater_than_zero:
+        return "Zero";
+      case select_op_type::even:
+        return "Even";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  },
+  [](select_op_type select_op) {
+    switch (select_op)
+    {
+      case select_op_type::greater_than_middle:
+        return "Return true for elements > Elements/2";
+      case select_op_type::greater_than_zero:
+        return "Return true for all elements";
+      case select_op_type::even:
+        return "Return true for even elements";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown data_pattern");
+  })
+
+using all_input_data_patterns =
+  nvbench::enum_type_list<tbm::data_pattern::sequence,
+                          tbm::data_pattern::constant,
+                          tbm::data_pattern::random>;
+
+NVBENCH_BENCH_TYPES(basic,
+                    NVBENCH_TYPE_AXES(types, ops, all_input_data_patterns))
+  .set_name("cub::DevicePartition::If")
+  .set_type_axes_names(select_if_type_axis_names())
+  .add_int64_power_of_two_axis("Elements", nvbench::range(22, 28, 2));

--- a/benches/cub/device/run_length_encode/basic.cu
+++ b/benches/cub/device/run_length_encode/basic.cu
@@ -1,0 +1,95 @@
+#include <nvbench/nvbench.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/random.h>
+#include <thrust/fill.h>
+
+#include <tbm/range_generator.cuh>
+
+#include <cub/device/device_run_length_encode.cuh>
+
+template <typename T>
+void basic(nvbench::state &state,
+           nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements);
+  thrust::device_vector<T> unique_output(elements);
+  thrust::device_vector<std::size_t> counts_output(elements);
+  thrust::device_vector<std::size_t> num_runs(1);
+
+  const auto pattern = state.get_string("Pattern");
+  if (pattern == "constant")
+  {
+    thrust::fill(input.begin(), input.end(), T{0});
+  }
+  else if (pattern == "sequence")
+  {
+    thrust::sequence(input.begin(), input.end());
+  }
+  else if (pattern == "random")
+  {
+    auto random_input =
+      tbm::make_range_generator<T,
+                                tbm::iterator_style::pointer,
+                                tbm::data_pattern::random>(elements);
+
+    thrust::copy(random_input.cbegin(),
+                 random_input.cend(),
+                 input.begin());
+    thrust::sort(input.begin(), input.end());
+  }
+
+  const T *d_input = thrust::raw_pointer_cast(input.data());
+  T *d_unique_output = thrust::raw_pointer_cast(unique_output.data());
+  std::size_t *d_counts_output = thrust::raw_pointer_cast(counts_output.data());
+  std::size_t *d_num_runs = thrust::raw_pointer_cast(num_runs.data());
+
+  {
+    state.add_element_count(elements);
+    state.add_global_memory_reads<T>(elements);
+
+    unique_output = input;
+    const auto unique_items = thrust::distance(
+      unique_output.begin(),
+      thrust::unique(unique_output.begin(), unique_output.end()));
+    state.add_global_memory_writes<T>(unique_items);
+    state.add_global_memory_writes<std::size_t>(unique_items + 1);
+  }
+
+  std::size_t temp_storage_bytes {};
+  cub::DeviceRunLengthEncode::Encode(nullptr,
+                                     temp_storage_bytes,
+                                     d_input,
+                                     d_unique_output,
+                                     d_counts_output,
+                                     d_num_runs,
+                                     static_cast<int>(elements));
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  nvbench::uint8_t *d_temp_storage =
+    thrust::raw_pointer_cast(temp_storage.data());
+
+  state.exec([&](nvbench::launch &launch) {
+    cub::DeviceRunLengthEncode::Encode(d_temp_storage,
+                                       temp_storage_bytes,
+                                       d_input,
+                                       d_unique_output,
+                                       d_counts_output,
+                                       d_num_runs,
+                                       static_cast<int>(elements),
+                                       launch.get_stream());
+  });
+}
+
+using types = nvbench::type_list<nvbench::int8_t,
+                                 nvbench::int16_t,
+                                 nvbench::int32_t,
+                                 nvbench::int64_t>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types))
+  .set_name("cub::DeviceRunLengthEncode::Encode")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 30, 2))
+  .add_string_axis("Pattern", {"const", "sequence", "random"});

--- a/benches/cub/device/segmented_radix_sort/keys.cu
+++ b/benches/cub/device/segmented_radix_sort/keys.cu
@@ -1,24 +1,17 @@
-#include <nvbench/nvbench.cuh>
-
 #include "segments_generator.cuh"
+#include "type_lists.cuh"
+
+#include <nvbench/nvbench.cuh>
 
 #include <thrust/binary_search.h>
 #include <thrust/device_vector.h>
-#include <thrust/transform.h>
-#include <thrust/sequence.h>
 #include <thrust/random.h>
-#include <thrust/fill.h>
-
-#include <tbm/range_generator.cuh>
-
-#include "type_lists.cuh"
-#include "type_traits"
 
 #include <cub/device/device_segmented_radix_sort.cuh>
 
+#include <type_traits>
 
-template <typename T,
-          sort_direction SortDirection>
+template <typename T, sort_direction SortDirection>
 void basic(nvbench::state &state,
            nvbench::type_list<T, nvbench::enum_type<SortDirection>>)
 {
@@ -39,12 +32,12 @@ void basic(nvbench::state &state,
 
   const int num_segments = static_cast<int>(offsets.size() - 1);
 
-  const T *d_input = thrust::raw_pointer_cast(input.data());
-  T *d_output = thrust::raw_pointer_cast(output.data());
+  const T *d_input                   = thrust::raw_pointer_cast(input.data());
+  T *d_output                        = thrust::raw_pointer_cast(output.data());
   const nvbench::uint32_t *d_offsets = thrust::raw_pointer_cast(offsets.data());
 
-  std::size_t temp_storage_bytes {};
-  if constexpr(SortDirection == sort_direction::ascending)
+  std::size_t temp_storage_bytes{};
+  if constexpr (SortDirection == sort_direction::ascending)
   {
     cub::DeviceSegmentedRadixSort::SortKeys(nullptr,
                                             temp_storage_bytes,
@@ -81,7 +74,7 @@ void basic(nvbench::state &state,
   state.add_global_memory_writes<T>(elements);
 
   state.exec([&](nvbench::launch &launch) {
-    if constexpr(SortDirection == sort_direction::ascending)
+    if constexpr (SortDirection == sort_direction::ascending)
     {
       cub::DeviceSegmentedRadixSort::SortKeys(d_temp_storage,
                                               temp_storage_bytes,

--- a/benches/cub/device/segmented_radix_sort/keys.cu
+++ b/benches/cub/device/segmented_radix_sort/keys.cu
@@ -1,0 +1,119 @@
+#include <nvbench/nvbench.cuh>
+
+#include "segments_generator.cuh"
+
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
+#include <thrust/transform.h>
+#include <thrust/sequence.h>
+#include <thrust/random.h>
+#include <thrust/fill.h>
+
+#include <tbm/range_generator.cuh>
+
+#include "type_lists.cuh"
+#include "type_traits"
+
+#include <cub/device/device_segmented_radix_sort.cuh>
+
+
+template <typename T,
+          sort_direction SortDirection>
+void basic(nvbench::state &state,
+           nvbench::type_list<T, nvbench::enum_type<SortDirection>>)
+{
+  const int elements = static_cast<int>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements);
+  thrust::device_vector<T> output(elements);
+
+  const auto pattern = state.get_string("Pattern");
+  const auto offsets = gen_offsets(pattern, elements);
+
+  const auto bits = state.get_string("Bits");
+
+  // cub::DeviceSegmentedRadixSort reads data multiple times. Limiting the
+  // number of bits is a way of having accurate throughput estimation.
+  const int first_bit = 0;
+  const int last_bit  = bits == "all" ? sizeof(T) * 8 : 4;
+
+  const int num_segments = static_cast<int>(offsets.size() - 1);
+
+  const T *d_input = thrust::raw_pointer_cast(input.data());
+  T *d_output = thrust::raw_pointer_cast(output.data());
+  const nvbench::uint32_t *d_offsets = thrust::raw_pointer_cast(offsets.data());
+
+  std::size_t temp_storage_bytes {};
+  if constexpr(SortDirection == sort_direction::ascending)
+  {
+    cub::DeviceSegmentedRadixSort::SortKeys(nullptr,
+                                            temp_storage_bytes,
+                                            d_input,
+                                            d_output,
+                                            elements,
+                                            num_segments,
+                                            d_offsets,
+                                            d_offsets + 1,
+                                            first_bit,
+                                            last_bit);
+  }
+  else
+  {
+    cub::DeviceSegmentedRadixSort::SortKeysDescending(nullptr,
+                                                      temp_storage_bytes,
+                                                      d_input,
+                                                      d_output,
+                                                      elements,
+                                                      num_segments,
+                                                      d_offsets,
+                                                      d_offsets + 1,
+                                                      first_bit,
+                                                      last_bit);
+  }
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  nvbench::uint8_t *d_temp_storage =
+    thrust::raw_pointer_cast(temp_storage.data());
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<nvbench::uint32_t>(num_segments, "Segments");
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec([&](nvbench::launch &launch) {
+    if constexpr(SortDirection == sort_direction::ascending)
+    {
+      cub::DeviceSegmentedRadixSort::SortKeys(d_temp_storage,
+                                              temp_storage_bytes,
+                                              d_input,
+                                              d_output,
+                                              elements,
+                                              num_segments,
+                                              d_offsets,
+                                              d_offsets + 1,
+                                              first_bit,
+                                              last_bit,
+                                              launch.get_stream());
+    }
+    else
+    {
+      cub::DeviceSegmentedRadixSort::SortKeysDescending(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        d_input,
+                                                        d_output,
+                                                        elements,
+                                                        num_segments,
+                                                        d_offsets,
+                                                        d_offsets + 1,
+                                                        first_bit,
+                                                        last_bit,
+                                                        launch.get_stream());
+    }
+  });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, directions))
+  .set_name("cub::DeviceSegmentedRadixSort::SortKeys")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 30, 2))
+  .add_string_axis("Bits", {"few", "all"})
+  .add_string_axis("Pattern", {"small", "large", "random"});

--- a/benches/cub/device/segmented_radix_sort/pairs.cu
+++ b/benches/cub/device/segmented_radix_sort/pairs.cu
@@ -1,0 +1,130 @@
+#include <nvbench/nvbench.cuh>
+
+#include "segments_generator.cuh"
+
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
+#include <thrust/transform.h>
+#include <thrust/sequence.h>
+#include <thrust/random.h>
+#include <thrust/fill.h>
+
+#include <tbm/range_generator.cuh>
+
+#include "type_lists.cuh"
+#include "type_traits"
+
+#include <cub/device/device_segmented_radix_sort.cuh>
+
+
+template <typename T,
+          sort_direction SortDirection>
+void basic(nvbench::state &state,
+           nvbench::type_list<T, nvbench::enum_type<SortDirection>>)
+{
+  const int elements = static_cast<int>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input_keys(elements);
+  thrust::device_vector<T> output_keys(elements);
+
+  thrust::device_vector<T> input_values(elements);
+  thrust::device_vector<T> output_values(elements);
+
+  const auto pattern = state.get_string("Pattern");
+  const auto offsets = gen_offsets(pattern, elements);
+
+  const auto bits = state.get_string("Bits");
+
+  // cub::DeviceSegmentedRadixSort reads data multiple times. Limiting the
+  // number of bits is a way of having accurate throughput estimation.
+  const int first_bit = 0;
+  const int last_bit  = bits == "all" ? sizeof(T) * 8 : 4;
+
+  const int num_segments = static_cast<int>(offsets.size() - 1);
+
+  const T *d_input_keys = thrust::raw_pointer_cast(input_keys.data());
+  T *d_output_keys = thrust::raw_pointer_cast(output_keys.data());
+  const T *d_input_values = thrust::raw_pointer_cast(input_values.data());
+  T *d_output_values = thrust::raw_pointer_cast(output_values.data());
+  const nvbench::uint32_t *d_offsets = thrust::raw_pointer_cast(offsets.data());
+
+  std::size_t temp_storage_bytes {};
+  if constexpr(SortDirection == sort_direction::ascending)
+  {
+    cub::DeviceSegmentedRadixSort::SortPairs(nullptr,
+                                             temp_storage_bytes,
+                                             d_input_keys,
+                                             d_output_keys,
+                                             d_input_values,
+                                             d_output_values,
+                                             elements,
+                                             num_segments,
+                                             d_offsets,
+                                             d_offsets + 1,
+                                             first_bit,
+                                             last_bit);
+  }
+  else
+  {
+    cub::DeviceSegmentedRadixSort::SortPairsDescending(nullptr,
+                                                       temp_storage_bytes,
+                                                       d_input_keys,
+                                                       d_output_keys,
+                                                       d_input_values,
+                                                       d_output_values,
+                                                       elements,
+                                                       num_segments,
+                                                       d_offsets,
+                                                       d_offsets + 1,
+                                                       first_bit,
+                                                       last_bit);
+  }
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  nvbench::uint8_t *d_temp_storage =
+    thrust::raw_pointer_cast(temp_storage.data());
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<nvbench::uint32_t>(num_segments, "Segments");
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  state.exec([&](nvbench::launch &launch) {
+    if constexpr(SortDirection == sort_direction::ascending)
+    {
+      cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage,
+                                               temp_storage_bytes,
+                                               d_input_keys,
+                                               d_output_keys,
+                                               d_input_values,
+                                               d_output_values,
+                                               elements,
+                                               num_segments,
+                                               d_offsets,
+                                               d_offsets + 1,
+                                               first_bit,
+                                               last_bit);
+    }
+    else
+    {
+      cub::DeviceSegmentedRadixSort::SortPairsDescending(d_temp_storage,
+                                                         temp_storage_bytes,
+                                                         d_input_keys,
+                                                         d_output_keys,
+                                                         d_input_values,
+                                                         d_output_values,
+                                                         elements,
+                                                         num_segments,
+                                                         d_offsets,
+                                                         d_offsets + 1,
+                                                         first_bit,
+                                                         last_bit);
+    }
+  });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types, directions))
+  .set_name("cub::DeviceSegmentedRadixSort::SortPairs")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2))
+  .add_string_axis("Bits", {"few", "all"})
+  .add_string_axis("Pattern", {"small", "large", "random"});

--- a/benches/cub/device/segmented_radix_sort/pairs.cu
+++ b/benches/cub/device/segmented_radix_sort/pairs.cu
@@ -1,24 +1,17 @@
-#include <nvbench/nvbench.cuh>
-
 #include "segments_generator.cuh"
+#include "type_lists.cuh"
+
+#include <nvbench/nvbench.cuh>
 
 #include <thrust/binary_search.h>
 #include <thrust/device_vector.h>
-#include <thrust/transform.h>
-#include <thrust/sequence.h>
 #include <thrust/random.h>
-#include <thrust/fill.h>
-
-#include <tbm/range_generator.cuh>
-
-#include "type_lists.cuh"
-#include "type_traits"
 
 #include <cub/device/device_segmented_radix_sort.cuh>
 
+#include <type_traits>
 
-template <typename T,
-          sort_direction SortDirection>
+template <typename T, sort_direction SortDirection>
 void basic(nvbench::state &state,
            nvbench::type_list<T, nvbench::enum_type<SortDirection>>)
 {
@@ -42,14 +35,14 @@ void basic(nvbench::state &state,
 
   const int num_segments = static_cast<int>(offsets.size() - 1);
 
-  const T *d_input_keys = thrust::raw_pointer_cast(input_keys.data());
-  T *d_output_keys = thrust::raw_pointer_cast(output_keys.data());
+  const T *d_input_keys   = thrust::raw_pointer_cast(input_keys.data());
+  T *d_output_keys        = thrust::raw_pointer_cast(output_keys.data());
   const T *d_input_values = thrust::raw_pointer_cast(input_values.data());
-  T *d_output_values = thrust::raw_pointer_cast(output_values.data());
+  T *d_output_values      = thrust::raw_pointer_cast(output_values.data());
   const nvbench::uint32_t *d_offsets = thrust::raw_pointer_cast(offsets.data());
 
-  std::size_t temp_storage_bytes {};
-  if constexpr(SortDirection == sort_direction::ascending)
+  std::size_t temp_storage_bytes{};
+  if constexpr (SortDirection == sort_direction::ascending)
   {
     cub::DeviceSegmentedRadixSort::SortPairs(nullptr,
                                              temp_storage_bytes,
@@ -90,7 +83,7 @@ void basic(nvbench::state &state,
   state.add_global_memory_writes<T>(elements);
 
   state.exec([&](nvbench::launch &launch) {
-    if constexpr(SortDirection == sort_direction::ascending)
+    if constexpr (SortDirection == sort_direction::ascending)
     {
       cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage,
                                                temp_storage_bytes,

--- a/benches/cub/device/segmented_radix_sort/segments_generator.cuh
+++ b/benches/cub/device/segmented_radix_sort/segments_generator.cuh
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
+#include <thrust/transform.h>
+#include <thrust/sequence.h>
+#include <thrust/random.h>
+#include <thrust/fill.h>
+
+#include <tbm/range_generator.cuh>
+
+thrust::device_vector<nvbench::uint32_t> gen_offsets(int segment_size,
+                                                     int elements)
+{
+  const int num_segments = (elements + segment_size - 1) / segment_size;
+  thrust::device_vector<nvbench::uint32_t> offsets(num_segments + 1);
+  thrust::fill(offsets.begin(),
+               offsets.end(),
+               static_cast<nvbench::uint32_t>(segment_size));
+  thrust::exclusive_scan(offsets.begin(), offsets.end(), offsets.begin());
+  offsets[num_segments] = elements;
+  return offsets;
+}
+
+
+template <typename T>
+struct SegmentSizeLimiter
+{
+  T out_max;
+
+  SegmentSizeLimiter(T out_max)
+    : out_max(out_max)
+  {}
+
+  __device__ T operator()(T in)
+  {
+    T guarded_value = in % out_max;
+    return guarded_value < 1 ? 1 : guarded_value;
+  }
+};
+
+
+thrust::device_vector<nvbench::uint32_t>
+gen_random(nvbench::uint32_t max_segment_size, int elements)
+{
+  thrust::device_vector<nvbench::uint32_t> offsets(elements);
+
+  auto random_input =
+    tbm::make_range_generator<nvbench::uint32_t,
+      tbm::iterator_style::pointer,
+      tbm::data_pattern::random>(elements);
+
+  thrust::transform(random_input.cbegin(),
+                    random_input.cend(),
+                    offsets.begin(),
+                    SegmentSizeLimiter<nvbench::uint32_t>{max_segment_size});
+
+  thrust::exclusive_scan(offsets.begin(), offsets.end(), offsets.begin());
+  const auto num_segments = thrust::distance(
+    offsets.begin(),
+    thrust::lower_bound(offsets.begin(),
+                        thrust::is_sorted_until(offsets.begin(), offsets.end()),
+                        static_cast<nvbench::uint32_t>(elements)));
+
+  offsets.resize(num_segments + 1);
+  offsets[num_segments] = elements;
+
+  return offsets;
+}
+
+
+thrust::device_vector<nvbench::uint32_t> gen_offsets(const std::string &pattern,
+                                                     int elements)
+{
+  if (pattern == "small")
+  {
+    return gen_offsets(4, elements);
+  }
+  else if (pattern == "large")
+  {
+    return gen_offsets(256 * 1024, elements);
+  }
+
+  return gen_random(16 * 1024, elements);
+}

--- a/benches/cub/device/segmented_radix_sort/segments_generator.cuh
+++ b/benches/cub/device/segmented_radix_sort/segments_generator.cuh
@@ -6,6 +6,7 @@
 #include <thrust/sequence.h>
 #include <thrust/random.h>
 #include <thrust/fill.h>
+#include <thrust/sort.h>
 
 #include <tbm/range_generator.cuh>
 

--- a/benches/cub/device/segmented_radix_sort/type_lists.cuh
+++ b/benches/cub/device/segmented_radix_sort/type_lists.cuh
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <nvbench/nvbench.cuh>
+
+enum class sort_direction
+{
+  ascending,
+  descending
+};
+
+using directions =
+  nvbench::enum_type_list<sort_direction::ascending, sort_direction::descending>;
+
+NVBENCH_DECLARE_ENUM_TYPE_STRINGS(
+  sort_direction,
+  [](sort_direction direction) {
+    switch (direction)
+    {
+      case sort_direction::ascending:
+        return "Ascend";
+      case sort_direction::descending:
+        return "Descend";
+      default:
+        break;
+    }
+    NVBENCH_THROW(std::runtime_error, "{}", "Unknown sort_direction");
+  },
+  // Don't need descriptions:
+  [](sort_direction) { return std::string{}; })
+
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;

--- a/benches/cub/device/segmented_reduce/basic.cu
+++ b/benches/cub/device/segmented_reduce/basic.cu
@@ -1,0 +1,144 @@
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
+#include <thrust/transform.h>
+#include <thrust/sequence.h>
+#include <thrust/random.h>
+#include <thrust/fill.h>
+
+#include <tbm/range_generator.cuh>
+
+#include <cub/device/device_segmented_reduce.cuh>
+
+thrust::device_vector<nvbench::uint32_t> gen_offsets(int segment_size,
+                                                     int elements)
+{
+  const int num_segments = (elements + segment_size - 1) / segment_size;
+  thrust::device_vector<nvbench::uint32_t> offsets(num_segments + 1);
+  thrust::fill(offsets.begin(),
+               offsets.end(),
+               static_cast<nvbench::uint32_t>(segment_size));
+  thrust::exclusive_scan(offsets.begin(), offsets.end(), offsets.begin());
+  offsets[num_segments] = elements;
+  return offsets;
+}
+
+
+template <typename T>
+struct SegmentSizeLimiter
+{
+  T out_max;
+
+  SegmentSizeLimiter(T out_max)
+    : out_max(out_max)
+  {}
+
+  __device__ T operator()(T in)
+  {
+    T guarded_value = in % out_max;
+    return guarded_value < 1 ? 1 : guarded_value;
+  }
+};
+
+
+thrust::device_vector<nvbench::uint32_t>
+gen_random(nvbench::uint32_t max_segment_size, int elements)
+{
+  thrust::device_vector<nvbench::uint32_t> offsets(elements);
+
+  auto random_input =
+    tbm::make_range_generator<nvbench::uint32_t,
+      tbm::iterator_style::pointer,
+      tbm::data_pattern::random>(elements);
+
+  thrust::transform(random_input.cbegin(),
+                    random_input.cend(),
+                    offsets.begin(),
+                    SegmentSizeLimiter<nvbench::uint32_t>{max_segment_size});
+
+  thrust::exclusive_scan(offsets.begin(), offsets.end(), offsets.begin());
+  const auto num_segments = thrust::distance(
+    offsets.begin(),
+    thrust::lower_bound(offsets.begin(),
+                        thrust::is_sorted_until(offsets.begin(), offsets.end()),
+                        static_cast<nvbench::uint32_t>(elements)));
+
+  offsets.resize(num_segments + 1);
+  offsets[num_segments] = elements;
+
+  return offsets;
+}
+
+
+thrust::device_vector<nvbench::uint32_t> gen_offsets(const std::string &pattern,
+                                                     int elements)
+{
+  if (pattern == "small")
+  {
+    return gen_offsets(4, elements);
+  }
+  else if (pattern == "large")
+  {
+    return gen_offsets(256 * 1024, elements);
+  }
+
+  return gen_random(16 * 1024, elements);
+}
+
+
+template <typename T>
+void basic(nvbench::state &state,
+           nvbench::type_list<T>)
+{
+  const int elements = static_cast<int>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> input(elements);
+  thrust::device_vector<T> output(elements);
+
+  const auto pattern = state.get_string("Pattern");
+  const auto offsets = gen_offsets(pattern, elements);
+
+  const int num_segments = static_cast<int>(offsets.size() - 1);
+
+  const T *d_input                   = thrust::raw_pointer_cast(input.data());
+  T *d_output                        = thrust::raw_pointer_cast(output.data());
+  const nvbench::uint32_t *d_offsets = thrust::raw_pointer_cast(offsets.data());
+
+  std::size_t temp_storage_bytes{};
+  cub::DeviceSegmentedReduce::Sum(nullptr,
+                                  temp_storage_bytes,
+                                  d_input,
+                                  d_output,
+                                  num_segments,
+                                  d_offsets,
+                                  d_offsets + 1);
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  nvbench::uint8_t *d_temp_storage =
+    thrust::raw_pointer_cast(temp_storage.data());
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<nvbench::uint32_t>(num_segments, "Segments");
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(num_segments);
+
+  state.exec([&](nvbench::launch &launch) {
+    cub::DeviceSegmentedReduce::Sum(d_temp_storage,
+                                    temp_storage_bytes,
+                                    d_input,
+                                    d_output,
+                                    num_segments,
+                                    d_offsets,
+                                    d_offsets + 1,
+                                    launch.get_stream());
+  });
+}
+
+using types = nvbench::type_list<nvbench::uint8_t,
+                                 nvbench::uint16_t,
+                                 nvbench::uint32_t,
+                                 nvbench::uint64_t>;
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(types))
+  .set_name("cub::DeviceSegmentedReduce::Sum")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(20, 28, 2))
+  .add_string_axis("Pattern", {"small", "large", "random"});

--- a/benches/cub/device/segmented_reduce/basic.cu
+++ b/benches/cub/device/segmented_reduce/basic.cu
@@ -1,9 +1,9 @@
 #include <thrust/binary_search.h>
 #include <thrust/device_vector.h>
-#include <thrust/transform.h>
-#include <thrust/sequence.h>
-#include <thrust/random.h>
 #include <thrust/fill.h>
+#include <thrust/random.h>
+#include <thrust/sort.h>
+#include <thrust/transform.h>
 
 #include <tbm/range_generator.cuh>
 
@@ -22,14 +22,13 @@ thrust::device_vector<nvbench::uint32_t> gen_offsets(int segment_size,
   return offsets;
 }
 
-
 template <typename T>
 struct SegmentSizeLimiter
 {
   T out_max;
 
   SegmentSizeLimiter(T out_max)
-    : out_max(out_max)
+      : out_max(out_max)
   {}
 
   __device__ T operator()(T in)
@@ -39,7 +38,6 @@ struct SegmentSizeLimiter
   }
 };
 
-
 thrust::device_vector<nvbench::uint32_t>
 gen_random(nvbench::uint32_t max_segment_size, int elements)
 {
@@ -47,8 +45,8 @@ gen_random(nvbench::uint32_t max_segment_size, int elements)
 
   auto random_input =
     tbm::make_range_generator<nvbench::uint32_t,
-      tbm::iterator_style::pointer,
-      tbm::data_pattern::random>(elements);
+                              tbm::iterator_style::pointer,
+                              tbm::data_pattern::random>(elements);
 
   thrust::transform(random_input.cbegin(),
                     random_input.cend(),
@@ -68,7 +66,6 @@ gen_random(nvbench::uint32_t max_segment_size, int elements)
   return offsets;
 }
 
-
 thrust::device_vector<nvbench::uint32_t> gen_offsets(const std::string &pattern,
                                                      int elements)
 {
@@ -84,10 +81,8 @@ thrust::device_vector<nvbench::uint32_t> gen_offsets(const std::string &pattern,
   return gen_random(16 * 1024, elements);
 }
 
-
 template <typename T>
-void basic(nvbench::state &state,
-           nvbench::type_list<T>)
+void basic(nvbench::state &state, nvbench::type_list<T>)
 {
   const int elements = static_cast<int>(state.get_int64("Elements"));
 


### PR DESCRIPTION
In this PR I've benchmarked the following algorithms:

- Device scope:
  - Partition
  - Run-length encode
  - Segmented radix sort
  - Segmented reduce
  - Select
- Block scope:
  - Discontinuity 
  - Histogram
  - Load
  - Store
  - Reduce
  - Scan

I suggest we proceed with the warp-scope benchmark after enabling device-side benchmarking. 